### PR TITLE
fix Plyr initialization element

### DIFF
--- a/src/plyr-audio.vue
+++ b/src/plyr-audio.vue
@@ -1,6 +1,5 @@
 <template>
   <audio
-    :id="`js-player-audio-${idNumber}`"
     ref="audio"
   >
     <source
@@ -53,13 +52,10 @@
       }
     },
     computed: {
-      idNumber () {
-        return Math.floor(Math.random() * (100000 - 1)) + 1
-      }
     },
     mounted () {
       const Plyr = require('plyr')
-      this.player = new Plyr(document.getElementById(`js-player-audio-${this.idNumber}`), this.options)
+      this.player = new Plyr(this.$el, this.options)
       this.emit.forEach(element => {
         this.player.on(element, this.emitPlayerEvent)
       })

--- a/src/plyr-video.vue
+++ b/src/plyr-video.vue
@@ -1,6 +1,5 @@
 <template>
   <video
-    :id="`js-player-video-${idNumber}`"
     class="video"
     ref="video"
     :poster="poster"
@@ -92,13 +91,10 @@
       }
     },
     computed: {
-      idNumber () {
-        return Math.floor(Math.random() * (100000 - 1)) + 1
-      }
     },
     mounted () {
       const Plyr = require('plyr')
-      this.player = new Plyr(document.getElementById(`js-player-video-${this.idNumber}`), this.options)
+      this.player = new Plyr(this.$el, this.options)
       this.emit.forEach(element => {
         this.player.on(element, this.emitPlayerEvent)
       })

--- a/src/plyr-vimeo.vue
+++ b/src/plyr-vimeo.vue
@@ -2,14 +2,12 @@
   <div
     v-if="pe"
     class="plyr__video-embed"
-    :id="`js-player-vimeo-${idNumber}`"
   >
     <iframe
       :src="`https://player.vimeo.com/video/${id}`"
       allowfullscreen allowtransparency allow="autoplay"></iframe>
   </div>
   <div v-else
-       :id="`js-player-vimeo-${idNumber}`"
        data-plyr-provider="vimeo"
        :data-plyr-embed-id="id"
   />
@@ -52,13 +50,10 @@
       }
     },
     computed: {
-      idNumber () {
-        return Math.floor(Math.random() * (100000 - 1)) + 1
-      }
     },
     mounted () {
       const Plyr = require('plyr')
-      this.player = new Plyr(document.getElementById(`js-player-vimeo-${this.idNumber}`), this.options)
+      this.player = new Plyr(this.$el, this.options)
       this.emit.forEach(element => {
         this.player.on(element, this.emitPlayerEvent)
       })

--- a/src/plyr-youtube.vue
+++ b/src/plyr-youtube.vue
@@ -2,7 +2,6 @@
   <div
     v-if="pe"
     class="plyr__youtube-embed"
-    :id="`js-player-yt-${idNumber}`"
   >
     <iframe
       :src="`https://www.youtube.com/embed/${id}`"
@@ -10,7 +9,6 @@
   </div>
   <div
     v-else
-    :id="`js-player-yt-${idNumber}`"
     data-plyr-provider="youtube"
     :data-plyr-embed-id="id"
   />
@@ -53,13 +51,10 @@
       }
     },
     computed: {
-      idNumber () {
-        return Math.floor(Math.random() * (100000 - 1)) + 1
-      }
     },
     mounted () {
       const Plyr = require('plyr')
-      this.player = new Plyr(document.getElementById(`js-player-yt-${this.idNumber}`), this.options)
+      this.player = new Plyr(this.$el, this.options)
       this.emit.forEach(element => {
         this.player.on(element, this.emitPlayerEvent)
       })

--- a/src/plyr.vue
+++ b/src/plyr.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="`plyr-container-${idNumber}`">
+  <div>
     <slot/>
   </div>
 </template>
@@ -30,14 +30,11 @@
       }
     },
     computed: {
-      idNumber () {
-        return Math.floor(Math.random() * (100000 - 1)) + 1
-      }
     },
     mounted () {
       const plyr = require('plyr')
       // noinspection JSPotentiallyInvalidConstructorUsage
-      this.player = new plyr(document.getElementById(`plyr-container-${this.idNumber}`).firstChild,
+      this.player = new plyr(this.$el.firstChild,
         this.options)
       this.emit.forEach(element => {
         this.player.on(element, this.emitPlayerEvent)


### PR DESCRIPTION
In using this component in a VuePress site, the element and it's idNumber were already defined during server side rendering (see below), but on first initialization of the component, the idNumber would be different than the SSR element ID, thus leaving access to a property (firstChild) on a null element.

I did a local test of my use case and this worked just fine.

```html
<div id="plyr-container-97407" class="plyr">
  <audio>
    <source src="..." type="audio/mp3">
  </audio>
</div>
```

```
TypeError: Cannot read property 'firstChild' of null
    at a.mounted (2.1a140d06.js:formatted:55)
    at Ce (app.88db0b0d.js:8)
    at Object.insert (app.88db0b0d.js:8)
    at $ (app.88db0b0d.js:8)
    at a.__patch__ (app.88db0b0d.js:8)
    at a.t._update (app.88db0b0d.js:8)
    at a.<anonymous> (app.88db0b0d.js:8)
    at Te.get (app.88db0b0d.js:8)
    at Te.run (app.88db0b0d.js:8)
    at Ee (app.88db0b0d.js:8)
```