### PR TITLE
remove css import in favor of SSR

### DIFF
--- a/src/VuePlyr.vue
+++ b/src/VuePlyr.vue
@@ -6,7 +6,6 @@
 
 <script>
   import Plyr from 'plyr'
-  import 'plyr/dist/plyr.css'
 
   export default {
     name: 'vue-plyr',


### PR DESCRIPTION
this will fix nuxt problems, then we should import the scss

css: [
    { src: 'plyr/src/sass/plyr.scss', lang: 'scss' }
  ],