### PR TITLE
Add missing backtick in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ export default {
     'vue-plyr/dist/vue-plyr.css'
   ]
 }
-``
+```
 
 ## Author
 


### PR DESCRIPTION
Add missing backtick in the SSR section of the readme