### PR TITLE
Plugin pass default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ import Vue from 'vue'
 import VuePlyr from 'vue-plyr'
 import 'vue-plyr/dist/vue-plyr.css' // only if your build system can import css, otherwise import it wherever you would import your css.
 
-Vue.use(VuePlyr)
+// Second argument with defaults can be omitted
+Vue.use(VuePlyr, {
+  plyr: {
+    fullscreen: { enabled: false }
+  },
+  emit: ['ended']
+})
 ```
 
 ## Usage
@@ -164,7 +170,13 @@ only the three lines:
 import Vue from 'vue'
 import VuePlyr from 'vue-plyr'
 
-Vue.use(VuePlyr)
+// Second argument with defaults can be omitted
+Vue.use(VuePlyr, {
+  plyr: {
+    fullscreen: { enabled: false }
+  },
+  emit: ['ended']
+})
 ```
 
 Then, in your `nuxt.config.js` file add `'~/plugins/vue-plyr'` to the plugins array. The `vue-plyr` element should be globally registered now. I might add a nuxt config file to the package at some point in the future so that you do not have to create the file yourself, but currently you have to make it manually.

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,8 @@
 import VuePlyr from './VuePlyr.vue'
 
-const Components = {
-  VuePlyr
-}
-
 const VuePlyrPlugin = {
   install (Vue, options) {
-    Object.keys(Components).forEach(component => {
-      Vue.component(Components[component].name, Components[component])
-    })
+    Vue.component(VuePlyr.name, VuePlyr)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,19 @@
 import VuePlyr from './VuePlyr.vue'
 
-const VuePlyrPlugin = {
-  install (Vue, options = {}) {
-    if (options.plyr) {
-      VuePlyr.props.options.default = () => { return { ...options.plyr } }
-    }
-    if (options.emit) {
-      VuePlyr.props.emit.default = () => { return [ ...options.emit ] }
-    }
-    Vue.component(VuePlyr.name, VuePlyr)
+VuePlyr.install = (Vue, options = {}) => {
+  if (options.plyr) {
+    VuePlyr.props.options.default = () => { return { ...options.plyr } }
   }
+  if (options.emit) {
+    VuePlyr.props.emit.default = () => { return [ ...options.emit ] }
+  }
+  Vue.component(VuePlyr.name, VuePlyr)
 }
 
 // Credit to https://github.com/irazasyed for this auto Vue.use() when
 // installing from unpkg or similar.
 if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.use(VuePlyrPlugin)
+  window.Vue.use(VuePlyr)
 }
 
-export {
-  VuePlyr,
-  VuePlyrPlugin
-}
-
-export default VuePlyrPlugin
+export default VuePlyr

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 import VuePlyr from './VuePlyr.vue'
 
 const VuePlyrPlugin = {
-  install (Vue, options) {
+  install (Vue, options = {}) {
+    if (options.plyr) {
+      VuePlyr.props.options.default = () => { return { ...options.plyr } }
+    }
+    if (options.emit) {
+      VuePlyr.props.emit.default = () => { return [ ...options.emit ] }
+    }
     Vue.component(VuePlyr.name, VuePlyr)
   }
 }


### PR DESCRIPTION
Is quite some time that I use a custom version of VuePlyrPlugin with Nuxt -similar to the one in this PR- to enable debug mode globally and to load translation strings conditionally based on what stored in application state (so components doesn't have to worry about setting the correct language for the user each time they instantiate a VuePlyr instance)

An updated example using this feature may be like this:
```
import Vue from 'vue'
import { VuePlyr } from 'vue-plyr'

export default ({ store }) => {
	const myPlyrDefaults = {
		plyr: {
			debug: process.env.DEBUG,
			vimeo: { speed: false },
			settings: []
		},
		emit: ['progress', 'ended']
	}

	// Conditionally require translation messages only from client-side
	if (process.browser) {
		const langCode = store.state.locale || process.env.fallbackLocale
		myPlyrDefaults.plyr.i18n = require(`~/locales/plyr/${langCode}.json`)
	}

	Vue.use(VuePlyr, myPlyrDefaults)
}
```