### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ export default {
     this.player.on('event', () => console.log('event fired'))
   }
 </script>
-``
+```
 
 The other way is to just pass an array of the
 events you want emitted.


### PR DESCRIPTION
There was a ` missing which was colliding with the following code tag.