### PR TITLE
Fix for 3.5.x version support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "dependencies": {
-    "plyr": "^3.5.10",
+    "plyr": "~3.5.10",
     "vue": "^2.6.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Plyr 3.6 doesn't work properly with vue-plyr